### PR TITLE
build: Upgrade Node.js from 22 to 24 (LTS)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,10 @@ jobs:
         uses: pnpm/action-setup@v5
         with:
           version: 10
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN apk add --no-cache python3 make g++
 RUN corepack enable
 WORKDIR /app
@@ -21,7 +21,7 @@ RUN npx tsc -p tsconfig.server.json
 RUN CI=true pnpm prune --prod
 
 # Production stage
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 RUN apk add --no-cache tini
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 RUN corepack enable
 WORKDIR /app
 CMD ["sh", "-c", "pnpm install && tail -f /dev/null"]


### PR DESCRIPTION
## Summary
- Upgrade Node.js from 22 to 24 (LTS) in `Dockerfile`, `Dockerfile.dev`, and CI workflow
- Tested with Node 24.14.1 — all 2750 tests pass, TypeScript compiles clean, client builds fine, production server starts and responds correctly

## Changes
- `Dockerfile`: `node:22-alpine` → `node:24-alpine` (build + production stages)
- `Dockerfile.dev`: `node:22-alpine` → `node:24-alpine`
- `.github/workflows/release.yaml`: `node-version: 22` → `node-version: 24`

## Deprecation warnings (from dependencies, not our code)
- `DEP0169` (`url.parse()`): from `swagger-jsdoc` → `@apidevtools/json-schema-ref-parser` — non-blocking
- `DEP0176` (`fs.R_OK`): from `better-sqlite3` → `prebuild-install` — build-time only

## Test plan
- [x] All 2750 tests pass on Node 24
- [x] TypeScript compiles without errors
- [x] Client builds successfully
- [x] Production server starts and responds to API requests
- [x] Native modules (better-sqlite3, esbuild) rebuild cleanly
